### PR TITLE
Add python inference API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# Python
+__pycache__/
+*.pyc
+pyapi/venv/

--- a/README.md
+++ b/README.md
@@ -3,3 +3,24 @@
 목적 : Redis 의 기본문법을 알아보기 위한 내용입니다. 
 
 사용강의 : 이커머스 프로젝트로 배우는 NoSQL & 대용량 데이터 처리 - 캐싱과 검색최적화-캐싱
+
+---
+
+## Python API
+
+`pyapi/app.py` 를 실행하면 Flask 기반의 간단한 모델 인퍼런스 API 서버가 실행됩니다. `MODEL_PATH` 환경변수로 모델 pkl 파일 경로를 지정할 수 있으며 기본값은 `model.pkl` 입니다.
+
+### 실행 방법
+
+```bash
+cd pyapi
+pip install -r requirements.txt
+python app.py
+```
+
+POST `/predict` 엔드포인트에 다음과 같이 호출하여 예측값을 받을 수 있습니다.
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+    -d '{"features": [1, 2, 3, 4]}' http://localhost:8000/predict
+```

--- a/pyapi/app.py
+++ b/pyapi/app.py
@@ -1,0 +1,30 @@
+from flask import Flask, request, jsonify
+import joblib
+import os
+
+# Load the model when the app starts
+MODEL_PATH = os.environ.get('MODEL_PATH', 'model.pkl')
+if os.path.exists(MODEL_PATH):
+    model = joblib.load(MODEL_PATH)
+else:
+    model = None
+
+app = Flask(__name__)
+
+@app.route('/predict', methods=['POST'])
+def predict():
+    if model is None:
+        return jsonify({'error': 'Model not found'}), 500
+    data = request.get_json(force=True)
+    # Assume data is a list of features
+    features = data.get('features')
+    if features is None:
+        return jsonify({'error': 'No features provided'}), 400
+    try:
+        prediction = model.predict([features])
+        return jsonify({'prediction': prediction[0]}), 200
+    except Exception as exc:
+        return jsonify({'error': str(exc)}), 500
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)

--- a/pyapi/requirements.txt
+++ b/pyapi/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+joblib


### PR DESCRIPTION
## Summary
- implement a simple Flask API in `pyapi/app.py`
- specify Flask and joblib dependencies
- ignore Python cache files
- document how to run the new API

## Testing
- `python3 -m py_compile pyapi/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d79597a4832eb7e02e0b7e8ed118